### PR TITLE
UGC-4220 | Add explicit replaceSelection() implementation

### DIFF
--- a/modules/jquery.codeEditor.js
+++ b/modules/jquery.codeEditor.js
@@ -770,6 +770,15 @@
 			},
 
 			/**
+			 * Replace the current selection with the given text.
+			 * Do not call this directly, use $.textSelection( 'functionname', options ) instead.
+			 * @param {string} text
+			 */
+			replaceSelection: function ( text ) {
+				context.codeEditor.insert( text );
+			},
+
+			/**
 			 * Gets the position (in resolution of bytes not nessecarily characters) in a textarea
 			 * DO NOT CALL THIS DIRECTLY, use $.textSelection( 'functionname', options ) instead
 			 */


### PR DESCRIPTION
TemplateData interacts with the source editor via the $.textSelection() wrapper, for which CodeEditor exposes a facade. This facade is missing an explicit replaceSelection() implementation, in the absence of which the plugin falls back to a naive implementation that errors out. So, provide a simple implementation that calls the appropriate Ace method.